### PR TITLE
Fixed tabulature to tablature typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Automatic Drum Transcription Library (ADTLib)
 
-The automatic drum transcription (ADT) library contains open source ADT algorithms to aid other researchers in areas of music information retrieval (MIR). The algorithms return both a .txt file of kick drum, snare drum, and hi-hat onsets and an automatically generated drum tabulature. 
+The automatic drum transcription (ADT) library contains open source ADT algorithms to aid other researchers in areas of music information retrieval (MIR). The algorithms return both a .txt file of kick drum, snare drum, and hi-hat onsets and an automatically generated drum tablature. 
 
 ### Browser Version (ADTWeb)
 

--- a/bin/ADT
+++ b/bin/ADT
@@ -14,7 +14,7 @@ p = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter
    -h	help	          displays help file	                                            n/a
    -od	output_dir	      location output files are saved	                            current
    -o	output_text	      defines whether the output is stored in a textfile or not	        yes
-   -ot  output_tab        defines whether a tabulature is created and saved to a pdf        yes
+   -ot  output_tab        defines whether a tablature is created and saved to a pdf        yes
    I	input_file_names  single or list of wav file names seperated by spaces	            n/a
  
   For further usage help see github.com/CarlSouthall/ADTLib/usage.md  

--- a/usage.md
+++ b/usage.md
@@ -11,22 +11,22 @@ This file contains information regarding using the toolbox.
 | -h     |  help             |   displays help file                                              | n/a     |                                        
 | -od    |   output_dir      |   location output .txt files are saved                            | None | 
 | -o      | output_text     | defines whether the output is stored in a .txt file or not    | yes |
-| -ot    |   output_tab     |   defines whether a tabulature is created and saved to a pdf       | yes|
+| -ot    |   output_tab     |   defines whether a tablature is created and saved to a pdf       | yes|
 | I      |   input_file_names|   single or list of drum.wav file names separated by spaces                     |  n/a |
 
 ##### Examples
 
     ADT Drum.wav
     
-Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tabulature and saves it as a pdf in the current directory.
+Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tablature and saves it as a pdf in the current directory.
     
     ADT Drum.wav Drum1.wav Drum2.wav
 
-Perform ADT on multiple audio files. Saves onset times to a .txt file in the current directory. Creates a drum tabulature and saves it as a pdf in the current directory.
+Perform ADT on multiple audio files. Saves onset times to a .txt file in the current directory. Creates a drum tablature and saves it as a pdf in the current directory.
     
     ADT -od ~/Desktop -o no ~/Drum.wav ~/Desktop/Drum1.wav 
 
-Perform ADT on multiple audio files from different directories. Creates a drum tabulature but not a .txt file and saves it to the desktop.
+Perform ADT on multiple audio files from different directories. Creates a drum tablature but not a .txt file and saves it to the desktop.
 
   
 ### Python function
@@ -41,7 +41,7 @@ Onsets=ADT(filenames, text='yes', tab='yes', save_dir=None, output_act='no')
 |  -------  | ----- |   ------   |   
 |       filenames      | Drum.wav files, must be in a list.                                        | n/a     |                                           
 |   text     |   defines whether the output is stored in a .txt file or not ('yes','no' )                           | 'yes' |
-|   tab  |   defines whether a tabulature is created and saved to a pdf ('yes','no' )                           | 'yes' |
+|   tab  |   defines whether a tablature is created and saved to a pdf ('yes','no' )                           | 'yes' |
 |   save_dir      |   location output .txt files are saved ('None' (saves in current dir), dir)                     | None | 
 |   output_act    |   defines whether the activation functions are also output ('yes','no')                     | 'no' | 
 
@@ -52,28 +52,28 @@ from ADTLib import ADT
 
 Onsets=ADT(['Drum.wav'])
 ```
-Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tabulature and saves it as a pdf in the current directory. Returns onset times per instrument.
+Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tablature and saves it as a pdf in the current directory. Returns onset times per instrument.
 
 ```Python
 from ADTLib import ADT
 
 Onsets=ADT(['Drum.wav', 'Drum1.wav', 'Drum2.wav'])
 ```
-Perform ADT on multiple audio files. Saves onset times to a .txt file in the current directory. Creates a drum tabulature and saves it as a pdf in the current directory. Returns onset times per instrument.
+Perform ADT on multiple audio files. Saves onset times to a .txt file in the current directory. Creates a drum tablature and saves it as a pdf in the current directory. Returns onset times per instrument.
 
 ```Python
 from ADTLib import ADT
 
 Onsets=ADT('~/Drum.wav', '~/Desktop/Drum1.wav', text='no', save_dir='~/Desktop')
 ```    
-Perform ADT on multiple audio files from different directories. Creates a drum tabulature but not a .txt file and saves it to the desktop. Returns onset times per instrument.
+Perform ADT on multiple audio files from different directories. Creates a drum tablature but not a .txt file and saves it to the desktop. Returns onset times per instrument.
 
 ```Python
 from ADTLib import ADTDT
 
 [Onsets, ActivationFunctions]=ADT(['Drum.wav'], output_act='yes')
 ```    
-Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tabulature and saves it as a pdf in the current directory. Returns onset times per instrument and activation functions per track, per instrument.
+Perform ADT on a single audio file. Saves onset times to a .txt file in the current directory. Creates a drum tablature and saves it as a pdf in the current directory. Returns onset times per instrument and activation functions per track, per instrument.
 
 
 


### PR DESCRIPTION
I have never seen the word spelt this way, and google does not recognize it either. If this is the word you really want to use to describe it, then this is a typo in my professional opinion. I would be very curious to hear your thoughts, especially if you disagree. Furthermore, the word tablature typically refers to string instruments like the guitar and violin, even if it is uncommon for the latter. 