### PR TITLE
Fixed 'IndexError: arrays used as indices must be of integer (or boolean) type'

### DIFF
--- a/ADTLib/utils/__init__.py
+++ b/ADTLib/utils/__init__.py
@@ -41,7 +41,7 @@ def meanPPmm(Track,Lambda,mi,ma,hop=512,fs=44100,dif=0.05):
     for i in range(1,len(onsets)):
         if abs(onsets[i]-onsets[i-1])<dif:
             ind=np.argmax(values[i-1:i+1])
-            np.delete(onsets,onsets[i-1+ind])
+            np.delete(onsets,onsets[i-1+ind].astype(int))
   
     return onsets
 


### PR DESCRIPTION
When trying to run the ADT function for a particular .wav file I got that error. Fixed by adding '.astype(int)':
[https://stackoverflow.com/questions/62329081/python-indexerror-arrays-used-as-indices-must-be-of-integer-or-boolean-type](https://stackoverflow.com/questions/62329081/python-indexerror-arrays-used-as-indices-must-be-of-integer-or-boolean-type)